### PR TITLE
Remove intermediate containers while building

### DIFF
--- a/src/midonet_sandbox/wrappers/docker_wrapper.py
+++ b/src/midonet_sandbox/wrappers/docker_wrapper.py
@@ -29,7 +29,7 @@ class Docker(object):
         log.debug('Invoking docker build on {}'.format(dockerfile))
 
         response = self._client.build(path=os.path.dirname(dockerfile),
-                                      tag=image, pull=False, rm=False,
+                                      tag=image, pull=False, rm=True,
                                       dockerfile=os.path.basename(dockerfile))
 
         for line in response:


### PR DESCRIPTION
So that it doesn't hold on to disk resources forever.