### PR TITLE
Add apt-get update so curl happily installs

### DIFF
--- a/src/midonet_sandbox/assets/images/cassandra/2.0/cassandra-2.0.dockerfile
+++ b/src/midonet_sandbox/assets/images/cassandra/2.0/cassandra-2.0.dockerfile
@@ -4,6 +4,7 @@ MAINTAINER MidoNet (http://midonet.org)
 # Configure cassandra repos
 RUN echo "deb http://debian.datastax.com/community 2.0 main" > /etc/apt/sources.list.d/cassandra.list
 
+RUN apt-get update
 RUN apt-get install -qqy curl
 RUN curl -L http://debian.datastax.com/debian/repo_key | apt-key add -
 


### PR DESCRIPTION
Since the base image has stale apt cache,
installation of curl would fail.
This patch fixes the problem.

Fixes: MNA-876