### PR TITLE
Include iptables on midolman images

### DIFF
--- a/src/midonet_sandbox/assets/images/midolman/base/midolman-base.dockerfile
+++ b/src/midonet_sandbox/assets/images/midolman/base/midolman-base.dockerfile
@@ -9,7 +9,7 @@ ONBUILD RUN apt-get -qy update
 ONBUILD RUN apt-get install -qy midolman zkdump python-setproctitle
 
 RUN apt-get -qy update
-RUN apt-get -qy install git mz tcpdump nmap --no-install-recommends
+RUN apt-get -qy install git mz tcpdump nmap iptables --no-install-recommends
 
 # Install Zulu Java 8
 RUN apt-get install -qy software-properties-common


### PR DESCRIPTION
This patch includes iptables to enable failure injections.

Signed-off-by: Xavi León <xavi.leon@midokura.com>