### PR TITLE
Fixing typos in image names for cluster and api

### DIFF
--- a/src/midonet_sandbox/assets/composer/base/midonet-api.yml
+++ b/src/midonet_sandbox/assets/composer/base/midonet-api.yml
@@ -1,3 +1,3 @@
 api:
-  image: sandobx/midonet-api
+  image: sandbox/midonet-api
 

--- a/src/midonet_sandbox/assets/composer/base/midonet-cluster.yml
+++ b/src/midonet_sandbox/assets/composer/base/midonet-cluster.yml
@@ -1,3 +1,3 @@
 cluster:
-  image: sandobx/midonet-cluster
+  image: sandbox/midonet-cluster
 


### PR DESCRIPTION
Replaced "sandobx" with "sandbox" in image names...