### PR TITLE
Quagga container improvements

### DIFF
--- a/src/midonet_sandbox/assets/images/midolman/base/midolman-base.dockerfile
+++ b/src/midonet_sandbox/assets/images/midolman/base/midolman-base.dockerfile
@@ -9,7 +9,7 @@ ONBUILD RUN apt-get -qy update
 ONBUILD RUN apt-get install -qy midolman zkdump python-setproctitle
 
 RUN apt-get -qy update
-RUN apt-get -qy install git mz tcpdump nmap iptables --no-install-recommends
+RUN apt-get -qy install git mz tcpdump nmap iptables telnet traceroute --no-install-recommends
 
 # Install Zulu Java 8
 RUN apt-get install -qy software-properties-common

--- a/src/midonet_sandbox/assets/images/midolman/master/bin/run-midolman.sh
+++ b/src/midonet_sandbox/assets/images/midolman/master/bin/run-midolman.sh
@@ -13,6 +13,9 @@ for IFACE in `env | grep _IFACE | cut -d= -f2 | sort -u`; do
     fi
 done
 
+# Add vtysh pager for easy debugging
+export VTYSH_PAGER=more
+
 # Midonet do not support ipv6
 sysctl -w net.ipv6.conf.all.disable_ipv6=1
 sysctl -w net.ipv6.conf.default.disable_ipv6=1

--- a/src/midonet_sandbox/assets/images/quagga/0.99.22/conf/bgpd.conf
+++ b/src/midonet_sandbox/assets/images/quagga/0.99.22/conf/bgpd.conf
@@ -9,6 +9,7 @@ hostname bgpd
 password zebra_password
 
 log file /var/log/quagga/bgpd.log
+debug bgp
 
 line vty
   no login
@@ -19,5 +20,4 @@ line vty
 
 router bgp 64512
     bgp router-id 10.255.255.255
-    network 0.0.0.0/0
     maximum-paths 2

--- a/src/midonet_sandbox/assets/images/quagga/0.99.22/quagga-0.99.22.dockerfile
+++ b/src/midonet_sandbox/assets/images/quagga/0.99.22/quagga-0.99.22.dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu-upstart:14.04
 MAINTAINER MidoNet (http://midonet.org)
 
-RUN apt-get -q update && apt-get install -qqy git quagga iptables
+RUN apt-get -q update && apt-get install -qqy git quagga iptables telnet traceroute
 
 # Get pipework to allow arbitrary configurations on the container from the host
 # Might get included into docker-networking in the future


### PR DESCRIPTION
This patch installs some packages on the images to help debugging,
enables the VTYSH_PAGER=more env variable for easier vtysh experience
and changes the quagga start script to configure the advertised network
for backwards compatibility.

Signed-off-by: Xavi León <xavi.leon@midokura.com>