### PR TITLE
Mount host timezone on containers for ease debug

### DIFF
--- a/src/midonet_sandbox/assets/composer/base/cassandra.yml
+++ b/src/midonet_sandbox/assets/composer/base/cassandra.yml
@@ -1,3 +1,6 @@
 cassandra:
   image: sandbox/cassandra
   privileged: true
+  volumes:
+  - /etc/localtime:/etc/localtime:ro
+  - /etc/timezone:/etc/timezone:ro

--- a/src/midonet_sandbox/assets/composer/base/cli.yml
+++ b/src/midonet_sandbox/assets/composer/base/cli.yml
@@ -1,2 +1,5 @@
 cli:
   image: sandbox/midonet-cli
+  volumes:
+  - /etc/localtime:/etc/localtime:ro
+  - /etc/timezone:/etc/timezone:ro

--- a/src/midonet_sandbox/assets/composer/base/keystone.yml
+++ b/src/midonet_sandbox/assets/composer/base/keystone.yml
@@ -1,2 +1,5 @@
 keystone:
   image: sandbox/keystone
+  volumes:
+  - /etc/localtime:/etc/localtime:ro
+  - /etc/timezone:/etc/timezone:ro

--- a/src/midonet_sandbox/assets/composer/base/midolman.yml
+++ b/src/midonet_sandbox/assets/composer/base/midolman.yml
@@ -1,3 +1,6 @@
 midolman:
   image: sandbox/midolman
   privileged: true
+  volumes:
+  - /etc/localtime:/etc/localtime:ro
+  - /etc/timezone:/etc/timezone:ro

--- a/src/midonet_sandbox/assets/composer/base/midonet-api.yml
+++ b/src/midonet_sandbox/assets/composer/base/midonet-api.yml
@@ -1,3 +1,6 @@
 api:
   image: sandbox/midonet-api
+  volumes:
+  - /etc/localtime:/etc/localtime:ro
+  - /etc/timezone:/etc/timezone:ro
 

--- a/src/midonet_sandbox/assets/composer/base/midonet-cluster.yml
+++ b/src/midonet_sandbox/assets/composer/base/midonet-cluster.yml
@@ -1,3 +1,6 @@
 cluster:
   image: sandbox/midonet-cluster
+  volumes:
+  - /etc/localtime:/etc/localtime:ro
+  - /etc/timezone:/etc/timezone:ro
 

--- a/src/midonet_sandbox/assets/composer/base/neutron.yml
+++ b/src/midonet_sandbox/assets/composer/base/neutron.yml
@@ -1,2 +1,5 @@
 neutron:
   image: sandbox/neutron
+  volumes:
+  - /etc/localtime:/etc/localtime:ro
+  - /etc/timezone:/etc/timezone:ro

--- a/src/midonet_sandbox/assets/composer/base/quagga.yml
+++ b/src/midonet_sandbox/assets/composer/base/quagga.yml
@@ -1,3 +1,6 @@
 quagga:
   image: sandbox/quagga
   privileged: true
+  volumes:
+  - /etc/localtime:/etc/localtime:ro
+  - /etc/timezone:/etc/timezone:ro

--- a/src/midonet_sandbox/assets/composer/base/vtep.yml
+++ b/src/midonet_sandbox/assets/composer/base/vtep.yml
@@ -1,3 +1,6 @@
 vtep:
   image: sandbox/vtep
   privileged: true
+  volumes:
+  - /etc/localtime:/etc/localtime:ro
+  - /etc/timezone:/etc/timezone:ro

--- a/src/midonet_sandbox/assets/composer/base/zookeeper.yml
+++ b/src/midonet_sandbox/assets/composer/base/zookeeper.yml
@@ -1,3 +1,6 @@
 zookeeper:
   image: sandbox/zookeeper
   privileged: true
+  volumes:
+  - /etc/localtime:/etc/localtime:ro
+  - /etc/timezone:/etc/timezone:ro


### PR DESCRIPTION
This patch adds volumes that mounts the host time zone data inside the
containers so containers and the host have the same time zone. This
helps when debugging timestamps from different log sources (container or
host).

Signed-off-by: Xavi León <xavi.leon@midokura.com>