### PR TITLE
Add the new public repo location to midolman

### DIFF
--- a/src/midonet_sandbox/assets/images/midolman/base/midolman-base.dockerfile
+++ b/src/midonet_sandbox/assets/images/midolman/base/midolman-base.dockerfile
@@ -5,6 +5,7 @@ ONBUILD ADD conf/midonet.list /etc/apt/sources.list.d/midonet.list
 ONBUILD ADD bin/run-midolman.sh /run-midolman.sh
 
 ONBUILD RUN curl -k http://repo.midonet.org/packages.midokura.key | apt-key add -
+ONBUILD RUN curl -k http://builds.midonet.org/midorepo.key | apt-key add -
 ONBUILD RUN apt-get -qy update
 ONBUILD RUN apt-get install -qy midolman zkdump python-setproctitle
 

--- a/src/midonet_sandbox/assets/images/midolman/master/conf/midonet.list
+++ b/src/midonet_sandbox/assets/images/midolman/master/conf/midonet.list
@@ -1,2 +1,2 @@
 deb http://repo.midonet.org/midonet/current stable main
-deb http://repo.midonet.org/misc stable main
+deb http://builds.midonet.org/misc stable main


### PR DESCRIPTION
Include the new repo location builds.midonet.org so the new quagga
packages can be fetched accordingly (only misc packages). The rest
of components will be updated once the whole repositories with all the
packages are moved to the new location.

Signed-off-by: Xavi León <xavi.leon@midokura.com>