### PR TITLE
Increase ZK tmpfs mount size

### DIFF
--- a/src/midonet_sandbox/assets/images/zookeeper/3.4.5/bin/run-zookeeper.sh
+++ b/src/midonet_sandbox/assets/images/zookeeper/3.4.5/bin/run-zookeeper.sh
@@ -8,7 +8,7 @@ fi
 mkdir -p /var/lib/zookeeper
 
 # keep zookeeper in-memory for performance
-mount -t tmpfs -o size=50m tmpfs /var/lib/zookeeper
+mount -t tmpfs -o size=1024m tmpfs /var/lib/zookeeper
 
 # Parse the IP address of the container
 IP=${LISTEN_ADDRESS:-`hostname --ip-address`}


### PR DESCRIPTION
This patch increases the ZK tmpf mount size to 1GB to support
having sandbox deployments running continuously for about a
week. This change should have no effect if less memory is used.

Signed-off-by: Duarte Nunes <duarte@midokura.com>