### PR TITLE
Increase timeout to wait for interface to be up

### DIFF
--- a/src/midonet_sandbox/assets/images/midolman/base/bin/run-midolman.sh
+++ b/src/midonet_sandbox/assets/images/midolman/base/bin/run-midolman.sh
@@ -6,7 +6,7 @@
 for IFACE in `env | grep _IFACE | cut -d= -f2`; do
     # TODO: change pipework by native docker networking once stable
     echo "Waiting for interface $IFACE to be up"
-    timeout 60s pipework --wait -i $IFACE
+    timeout 300s pipework --wait -i $IFACE
     if [ $? -eq 124 ]; then
         echo "Interface $IFACE was not ready after 60s. Exiting..."
         exit 1

--- a/src/midonet_sandbox/assets/images/midolman/master/bin/run-midolman.sh
+++ b/src/midonet_sandbox/assets/images/midolman/master/bin/run-midolman.sh
@@ -6,7 +6,7 @@
 for IFACE in `env | grep _IFACE | cut -d= -f2 | sort -u`; do
     # TODO: change pipework by native docker networking once stable
     echo "Waiting for interface $IFACE to be up"
-    timeout 60s pipework --wait -i $IFACE
+    timeout 300s pipework --wait -i $IFACE
     if [ $? -eq 124 ]; then
         echo "Interface $IFACE was not ready after 60s. Exiting..."
         exit 1

--- a/src/midonet_sandbox/assets/images/quagga/0.99.22/bin/run-quagga.sh
+++ b/src/midonet_sandbox/assets/images/quagga/0.99.22/bin/run-quagga.sh
@@ -6,7 +6,7 @@
 for IFACE in `env | grep -Ev "ENV" | grep _IFACE | cut -d= -f2 | sort -u`; do
     # TODO: change pipework by native docker networking once stable
     echo "Waiting for interface $IFACE to be up through pipework"
-        timeout 60s pipework --wait -i $IFACE
+        timeout 300s pipework --wait -i $IFACE
         if [ $? -eq 124 ]; then
             echo "Interface $IFACE was not ready after 60s. Exiting..."
             exit 1


### PR DESCRIPTION
Containers (specially those that start at the beginning of a sandbox
flavour) that wait for interfaces to be set up externally (midolman and
quagga for the bgp interfaces) fire a timeout because the provisioning
scripts are executed too late in the boot sequence. Increase this
timeout so containers do not exit too soon to reduce the likelihood of
this happening on loaded machines (e.g. CI infra).

Signed-off-by: Xavi León <xavi.leon@midokura.com>