### PR TITLE
Use DEBUG level on midonet-cluster

### DIFF
--- a/src/midonet_sandbox/assets/images/midonet-cluster/base/bin/run-midonetcluster.sh
+++ b/src/midonet_sandbox/assets/images/midonet-cluster/base/bin/run-midonetcluster.sh
@@ -20,5 +20,8 @@ MIDO_CFG_FILE=`cat $CLUSTER_ENV | grep "MIDO_CFG_FILE" | tr -d '[[:space:]]' | c
 
 sed -i -e 's/zookeeper_hosts = .*$/zookeeper_hosts = '"$ZK_HOSTS"'/' $MIDO_CFG/$MIDO_CFG_FILE
 
+# Update cluster logs to report DEBUG
+sed -i 's/<root level="INFO">/<root level="DEBUG">/' logback.xml
+
 # Run cluster
 exec /sbin/init


### PR DESCRIPTION
The midonet-cluster package uses INFO level by default. Change it to DEBUG
on the sandbox images so complete log reporting is done on the logs.

Signed-off-by: Xavi León <xavi.leon@midokura.com>